### PR TITLE
更新 soup 的选择语句

### DIFF
--- a/zhihu.py
+++ b/zhihu.py
@@ -700,9 +700,9 @@ class User:
             if self.soup == None:
                 self.parser()
             soup = self.soup
-            asks_num = int(soup.find_all("span", class_="num")[0].string)
+            ask_num=int(soup.find_all('a',href="/people/"+self.user_id+"/asks").find("span").string)
             return asks_num
-
+    
     def get_answers_num(self):
         if self.user_url == None:
             print "I'm anonymous user."

--- a/zhihu.py
+++ b/zhihu.py
@@ -700,7 +700,8 @@ class User:
             if self.soup == None:
                 self.parser()
             soup = self.soup
-            ask_num = int(soup.find_all('a',href="/people/"+self.user_id+"/asks").find("span").string)
+            ask_num = int(soup.find_all('a', href="/people/" +
+                                        self.user_id + "/asks").find("span").string)
             return asks_num
     
     def get_answers_num(self):

--- a/zhihu.py
+++ b/zhihu.py
@@ -700,7 +700,7 @@ class User:
             if self.soup == None:
                 self.parser()
             soup = self.soup
-            ask_num=int(soup.find_all('a',href="/people/"+self.user_id+"/asks").find("span").string)
+            ask_num = int(soup.find_all('a',href="/people/"+self.user_id+"/asks").find("span").string)
             return asks_num
     
     def get_answers_num(self):


### PR DESCRIPTION
实际上感觉这个好像更适合作为 issue 而非 PR 提出来，⊙﹏⊙b汗

原选择语句为：asks_num = int(soup.find_all("span", class_="num")[0].string)

更改后读取的是同一位置：ask_num = int(soup.find_all('a', href="/people/" +
                                        self.user_id + "/asks").find("span").string)

但可读性更加良好～

对于下面的 get_answer_num 也可以考虑更改～，不通过相对位置来获取 string

---

最后一个 PR 了

好吧，通读了一早上的源码，自己写了个 fake-zhihu-python 的程序。只有说 orz……

不过 chrome 的开发工具好像对表单的读取不够好，最后在虚拟机里用 fiddler 来抓取解决～

3 个 PR 指向三个部分，看 LZ 怎么选择，希望能多多交流呀