### PR TITLE
修复Windows下命令行颜色可能不显示的问题

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -8,6 +8,10 @@ from getpass import getpass
 
 # requirements
 import requests, termcolor
+import colorama
+
+
+colorama.init()
 
 
 requests = requests.Session()

--- a/zhihu.py
+++ b/zhihu.py
@@ -54,7 +54,7 @@ import os, sys, time, platform, random
 import re, json, cookielib
 
 # requirements
-import requests, termcolor, html2text
+import requests, termcolor, html2text, colorama
 try:
     from bs4 import BeautifulSoup
 except:
@@ -74,6 +74,8 @@ from auth import Logging
     By Luozijun (https://github.com/LuoZijun), 09/09 2015
 
 """
+colorama.init()
+
 requests = requests.Session()
 requests.cookies = cookielib.LWPCookieJar('cookies')
 try:


### PR DESCRIPTION
Windows系统下终端无法显示颜色，参看：
[Why termcolor doesn't work in python](http://stackoverflow.com/questions/21858567/why-termcolor-doesnt-work-in-python)